### PR TITLE
Changed Express Validator according to new syntax 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
-const expressValidator = require('express-validator');
+const {check , expressValidator } = require('express-validator');
 const flash = require('connect-flash');
 const session = require('express-session');
 


### PR DESCRIPTION
Check this link for reference : 
[link](https://stackoverflow.com/questions/56711444/typeerror-validator-is-not-a-function-after-installing-and-requiring-express) 